### PR TITLE
removing dedupe plugin in prod to make material-ui work

### DIFF
--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -24,8 +24,10 @@ module.exports = require('./webpack.base.babel')({
       async: true,
     }),
 
-    // Merge all duplicate modules
-    new webpack.optimize.DedupePlugin(),
+    // remove DedupePlugin in prod
+    // https://github.com/react-boilerplate/react-boilerplate/issues/1210
+    // // Merge all duplicate modules
+    // new webpack.optimize.DedupePlugin(),
 
     // Minify and optimize the index.html
     new HtmlWebpackPlugin({


### PR DESCRIPTION
removing dedupe plugin because prod is not building correctly, hopefully this will fix the problem after looking through:
- https://github.com/webpack/webpack/issues/959
- https://github.com/react-boilerplate/react-boilerplate/issues/1210