### PR TITLE
Add logout flow

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -49,14 +49,8 @@ const history = syncHistoryWithStore(browserHistory, store, {
   selectLocationState: selectLocationState(),
 });
 
-// Set up the router, wrapping all Routes in the App component
-import App from 'containers/App';
+// Import routes
 import createRoutes from './routes';
-const rootRoute = {
-  component: App,
-  childRoutes: createRoutes(store),
-};
-
 
 const render = (translatedMessages) => {
   ReactDOM.render(
@@ -65,7 +59,7 @@ const render = (translatedMessages) => {
         <LanguageProvider messages={translatedMessages}>
           <Router
             history={history}
-            routes={rootRoute}
+            routes={createRoutes(store)}
             render={
               // Scroll to top when going to a new page, imitating default browser
               // behaviour

--- a/app/containers/App/actions.js
+++ b/app/containers/App/actions.js
@@ -1,0 +1,36 @@
+/*
+ *
+ * Logout actions
+ *
+ */
+import {
+  LOGOUT,
+  LOGOUT_SUCCESS,
+  LOGOUT_ERROR,
+} from './constants';
+
+export function logout() {
+  return {
+    type: LOGOUT,
+  };
+}
+
+export function logoutSuccess(response) {
+  if (response.error) {
+    return {
+      type: LOGOUT_ERROR,
+      error: response.error,
+    };
+  }
+  return {
+    type: LOGOUT_SUCCESS,
+    loggedIn: response,
+  };
+}
+
+export function loggingOutError(response) {
+  return {
+    type: LOGOUT_ERROR,
+    error: response,
+  };
+}

--- a/app/containers/App/constants.js
+++ b/app/containers/App/constants.js
@@ -10,3 +10,7 @@
  */
 
 export const DEFAULT_LOCALE = 'en';
+
+export const LOGOUT = 'app/LOGOUT';
+export const LOGOUT_SUCCESS = 'app/LOGOUT_SUCCESS';
+export const LOGOUT_ERROR = 'app/LOGOUT_ERROR';

--- a/app/containers/App/index.js
+++ b/app/containers/App/index.js
@@ -11,19 +11,63 @@
  * the linting exception.
  */
 
-import React from 'react';
+import React, { PropTypes } from 'react';
+import { createStructuredSelector } from 'reselect';
+import { connect } from 'react-redux';
+import { push } from 'react-router-redux';
+import AppBar from 'material-ui//AppBar';
+import IconButton from 'material-ui/IconButton';
+import FlatButton from 'material-ui/FlatButton';
+import NavigationClose from 'material-ui/svg-icons/navigation/close';
+import { browserHistory } from 'react-router';
 
-export default class App extends React.PureComponent { // eslint-disable-line react/prefer-stateless-function
+import { selectLoggedIn } from './selectors';
+import { logout } from './actions';
+
+export class App extends React.PureComponent { // eslint-disable-line react/prefer-stateless-function
 
   static propTypes = {
-    children: React.PropTypes.node,
+    children: PropTypes.node,
+    loggedIn: PropTypes.bool.isRequired,
+    loginRedirect: PropTypes.func.isRequired,
+    tryLogout: PropTypes.func.isRequired,
   };
 
+  componentWillMount() {
+    if (!this.props.loggedIn) {
+      browserHistory.push('/login');
+    }
+  }
+
   render() {
+    const { loggedIn,
+            tryLogout,
+            loginRedirect } = this.props;
     return (
       <div>
+        <AppBar
+          title="SBG Monkeys"
+          iconElementLeft={<IconButton><NavigationClose /></IconButton>}
+          iconElementRight={
+            loggedIn ?
+              <FlatButton label="logout" onTouchTap={tryLogout} /> :
+                <FlatButton label="sign in" onTouchTap={loginRedirect} />}
+        />
         {React.Children.toArray(this.props.children)}
       </div>
     );
   }
 }
+
+const mapStateToProps = createStructuredSelector({
+  loggedIn: selectLoggedIn(),
+});
+
+function mapDispatchToProps(dispatch) {
+  return {
+    tryLogout: () => dispatch(logout()),
+    loginRedirect: () => dispatch(push('/login')),
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(App);

--- a/app/containers/App/reducer.js
+++ b/app/containers/App/reducer.js
@@ -1,0 +1,25 @@
+import { fromJS } from 'immutable';
+
+import authorize from 'containers/Login/authorize';
+import { LOGOUT_SUCCESS, LOGOUT_ERROR } from './constants';
+
+export const initialState = fromJS({
+  loggedIn: false,
+  error: false,
+});
+
+function authorizeReducer(state = initialState, action) {
+  switch (action.type) {
+    case LOGOUT_SUCCESS:
+      return state
+        .set('loggedIn', action.loggedIn);
+    case LOGOUT_ERROR:
+      return state
+        .set('error', action.error);
+    default:
+      return state
+        .set('loggedIn', authorize.loggedIn());
+  }
+}
+
+export default authorizeReducer;

--- a/app/containers/App/sagas.js
+++ b/app/containers/App/sagas.js
@@ -1,0 +1,37 @@
+import { call,
+         cancel,
+         fork,
+         put,
+         take } from 'redux-saga/effects';
+import { LOCATION_CHANGE } from 'react-router-redux';
+import { browserHistory } from 'react-router';
+
+import { LOGOUT } from './constants';
+import { logoutSuccess } from './actions';
+import authorize from 'containers/Login/authorize';
+
+
+/** Logout saga
+*/
+export function* logoutFlow() {
+  while (true) {
+    yield take(LOGOUT);
+    const wasSuccessful = yield call(authorize.logout);
+
+    if (wasSuccessful) {
+      yield put(logoutSuccess(wasSuccessful));
+      yield call(browserHistory.push, '/logout');
+    }
+  }
+}
+
+export function* logoutFlowWatcher() {
+  const watcher = yield fork(logoutFlow);
+
+  yield take(LOCATION_CHANGE);
+  yield cancel(watcher);
+}
+
+export default [
+  logoutFlowWatcher,
+];

--- a/app/containers/App/selectors.js
+++ b/app/containers/App/selectors.js
@@ -1,3 +1,5 @@
+import { createSelector } from 'reselect';
+
 // selectLocationState expects a plain JS object for the routing state
 const selectLocationState = () => {
   let prevRoutingState;
@@ -15,6 +17,15 @@ const selectLocationState = () => {
   };
 };
 
+const selectApp = () => (state) => state.get('app');
+
+const selectLoggedIn = () => createSelector(
+  selectApp(),
+  (authorizeState) => authorizeState.get('loggedIn')
+);
+
 export {
   selectLocationState,
+  selectApp,
+  selectLoggedIn,
 };

--- a/app/containers/App/tests/actions.test.js
+++ b/app/containers/App/tests/actions.test.js
@@ -1,0 +1,49 @@
+import expect from 'expect';
+
+import {
+  LOGOUT,
+  LOGOUT_SUCCESS,
+  LOGOUT_ERROR,
+} from '../constants';
+import { logout, logoutSuccess, loggingOutError } from '../actions';
+import { errorMessage } from 'tests/fixtures';
+
+
+describe('app Actions', () => {
+  describe('logout', () => {
+    it('should return the correct type', () => {
+      const expected = {
+        type: LOGOUT,
+      };
+      expect(logout()).toEqual(expected);
+    });
+  });
+
+  describe('logoutSuccess', () => {
+    it('should return the correct type and loggedIn response', () => {
+      const expected = {
+        type: LOGOUT_SUCCESS,
+        loggedIn: true,
+      };
+      expect(logoutSuccess(true)).toEqual(expected);
+    });
+
+    it('should error when the server responds in error', () => {
+      const expected = {
+        type: LOGOUT_ERROR,
+        error: errorMessage,
+      };
+      expect(logoutSuccess({ error: errorMessage })).toEqual(expected);
+    });
+  });
+
+  describe('loggingOutError', () => {
+    it('should return the correct type and the error', () => {
+      const expected = {
+        type: LOGOUT_ERROR,
+        error: errorMessage.msg,
+      };
+      expect(loggingOutError(errorMessage.msg)).toEqual(expected);
+    });
+  });
+});

--- a/app/containers/App/tests/index.test.js
+++ b/app/containers/App/tests/index.test.js
@@ -1,0 +1,55 @@
+/**
+ * Test App
+*/
+
+import expect from 'expect';
+import React from 'react';
+import { mount } from 'enzyme';
+import AppBar from 'material-ui//AppBar';
+import FlatButton from 'material-ui/FlatButton';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
+
+import { App } from '../index';
+import { EMPTY_FUNCTION } from 'tests/fixtures';
+
+describe('<App />', () => {
+  const mountWithContext = (node) => mount(node, {
+    context: {
+      muiTheme: getMuiTheme(),
+    },
+    childContextTypes: {
+      muiTheme: React.PropTypes.object.isRequired,
+    },
+  });
+
+  it('should render the AppBar with sign in button when not logged in', () => {
+    const loginRedirectSpy = expect.createSpy();
+    const renderedComponent = mountWithContext(
+      <App
+        loginRedirect={loginRedirectSpy}
+        tryLogout={EMPTY_FUNCTION}
+        loggedIn={false}
+      />);
+    const AppBarComponent = renderedComponent.find(AppBar).node;
+    const FlatButtonComponent = renderedComponent.find(FlatButton).node;
+    expect(AppBarComponent).toExist();
+    expect(FlatButtonComponent.props.label).toEqual('sign in');
+    expect(FlatButtonComponent.props.onTouchTap).toEqual(loginRedirectSpy);
+  });
+
+  it('should render the AppBar with logout button when logged in', () => {
+    const tryLogoutSpy = expect.createSpy();
+    const renderedComponent = mountWithContext(
+      <App
+        loginRedirect={EMPTY_FUNCTION}
+        tryLogout={tryLogoutSpy}
+        loggedIn
+      />
+    );
+    const AppBarComponent = renderedComponent.find(AppBar).node;
+    const FlatButtonComponent = renderedComponent.find(FlatButton).node;
+    expect(AppBarComponent).toExist();
+    expect(FlatButtonComponent.props.label).toEqual('logout');
+    expect(FlatButtonComponent.props.onTouchTap).toEqual(tryLogoutSpy);
+  });
+});

--- a/app/containers/App/tests/reducer.test.js
+++ b/app/containers/App/tests/reducer.test.js
@@ -1,0 +1,44 @@
+import expect from 'expect';
+
+import authorizeReducer, { initialState } from '../reducer';
+import { logout,
+         logoutSuccess,
+         loggingOutError } from '../actions';
+import {
+  errorMessage,
+} from 'tests/fixtures';
+
+describe('authorizeReducer', () => {
+  let state;
+  beforeEach(() => {
+    state = initialState;
+  });
+
+  it('returns the initial state', () => {
+    const expected = state;
+    expect(authorizeReducer(undefined, {})).toEqual(expected);
+  });
+
+  it('should handle the logout action correctly', () => {
+    const expected = state;
+    expect(authorizeReducer(state, logout())).toEqual(expected);
+  });
+
+  it('should handle the logoutSuccess action correctly when authorization succeeds', () => {
+    const expected = state
+      .set('loggedIn', true);
+    expect(authorizeReducer(state, logoutSuccess(true))).toEqual(expected);
+  });
+
+  it('should handle the logoutSuccess action correctly when authorization fails', () => {
+    const expected = state
+      .set('loggedIn', false);
+    expect(authorizeReducer(state, logoutSuccess(false))).toEqual(expected);
+  });
+
+  it('should handle the loggingOutError action correctly', () => {
+    const expected = state
+      .set('error', errorMessage);
+    expect(authorizeReducer(state, loggingOutError(errorMessage))).toEqual(expected);
+  });
+});

--- a/app/containers/App/tests/sagas.test.js
+++ b/app/containers/App/tests/sagas.test.js
@@ -1,0 +1,65 @@
+import expect from 'expect';
+import { call,
+         cancel,
+         fork,
+         put,
+         take } from 'redux-saga/effects';
+import { LOCATION_CHANGE } from 'react-router-redux';
+import { browserHistory } from 'react-router';
+
+import { LOGOUT } from '../constants';
+import { logoutSuccess } from '../actions';
+import authorize from 'containers/Login/authorize';
+import { logoutFlow, logoutFlowWatcher } from '../sagas';
+
+
+describe('logoutFlow Saga', () => {
+  const logoutFlowGenerator = logoutFlow();
+
+  it('should watch for LOGOUT action', () => {
+    const takeDescriptor = logoutFlowGenerator.next().value;
+    expect(takeDescriptor).toEqual(take(LOGOUT));
+  });
+
+  it('should call to authorize logout from the server', () => {
+    const logoutRequestMock = {
+      type: LOGOUT,
+    };
+    const callDescriptor = logoutFlowGenerator.next(logoutRequestMock).value;
+    expect(callDescriptor).toEqual(call(authorize.logout));
+  });
+
+  it('should dispatch the logoutSuccess action if logout succeeds', () => {
+    const wasSuccessful = true;
+    const putDescriptor = logoutFlowGenerator.next(wasSuccessful).value;
+    expect(putDescriptor).toEqual(put(logoutSuccess(wasSuccessful)));
+  });
+
+  it('should reroute to /logout', () => {
+    const callDescriptor = logoutFlowGenerator.next().value;
+    expect(callDescriptor).toEqual(call(browserHistory.push, '/logout'));
+  });
+});
+
+describe('logoutFlowWatcher Saga', () => {
+  const logoutFlowWatcherGenerator = logoutFlowWatcher();
+  let forkDescriptor;
+
+  it('should asynchronously fork logoutFlow saga', () => {
+    forkDescriptor = logoutFlowWatcherGenerator.next().value;
+    expect(forkDescriptor).toEqual(fork(logoutFlow));
+  });
+
+  it('should yield until LOCATION_CHANGE action', () => {
+    const takeDescriptor = logoutFlowWatcherGenerator.next().value;
+    expect(takeDescriptor).toEqual(take(LOCATION_CHANGE));
+  });
+
+  it('should finally cancel the forked logoutFlow saga',
+    function* logoutFlowWatcherSagaCancellable() {
+      forkDescriptor = logoutFlowWatcherGenerator.next(put(LOCATION_CHANGE)).value;
+      expect(forkDescriptor).toEqual(cancel(forkDescriptor));
+    }
+  );
+});
+

--- a/app/containers/App/tests/selectors.test.js
+++ b/app/containers/App/tests/selectors.test.js
@@ -1,7 +1,11 @@
 import { fromJS } from 'immutable';
 import expect from 'expect';
 
-import { selectLocationState } from 'containers/App/selectors';
+import { selectLocationState,
+         selectApp,
+         selectLoggedIn } from '../selectors';
+import { initialState } from '../reducer';
+
 
 describe('selectLocationState', () => {
   it('should select the route as a plain JS object', () => {
@@ -12,5 +16,27 @@ describe('selectLocationState', () => {
       route,
     });
     expect(selectLocationState()(mockedState)).toEqual(route.toJS());
+  });
+});
+
+describe('selectApp', () => {
+  const appSelector = selectApp();
+  it('should select the app state', () => {
+    const mockedState = fromJS({
+      app: initialState,
+    });
+    expect(appSelector(mockedState)).toEqual(initialState);
+  });
+});
+
+describe('selectLoggedIn', () => {
+  const loggedInSelector = selectLoggedIn();
+  it('should select loggedIn', () => {
+    const mockedState = fromJS({
+      app: {
+        loggedIn: true,
+      },
+    });
+    expect(loggedInSelector(mockedState)).toEqual(true);
   });
 });

--- a/app/containers/Login/authorize.js
+++ b/app/containers/Login/authorize.js
@@ -46,11 +46,15 @@ const authorize = {
   * Logs the current user out
   */
   logout() {
-    request('api/logout',
+    return request(
+      'api/logout',
       {
         method: 'POST',
       }
-    ).then(() => {
+    ).then((response) => {
+      if (response.error) {
+        return Promise.reject(response.error);
+      }
       localStorage.clear();
       return Promise.resolve(true);
     });

--- a/app/containers/Login/sagas.js
+++ b/app/containers/Login/sagas.js
@@ -54,7 +54,7 @@ export function* loginFlow() {
 
     if (winner.authorize) {
       yield put(authorizedSuccess(winner.authorize));
-      browserHistory.push('/');
+      yield call(browserHistory.push, '/');
     }
   }
 }

--- a/app/containers/Login/tests/index.test.js
+++ b/app/containers/Login/tests/index.test.js
@@ -11,7 +11,7 @@ describe('<Login />', () => {
     const wrapper = shallow(
       <Login
         tryLogin={EMPTY_FUNCTION}
-        resetPasswordRedirct={EMPTY_FUNCTION}
+        resetPasswordRedirect={EMPTY_FUNCTION}
       />
     );
     const loginFormComponent = wrapper.find(LoginForm);

--- a/app/containers/Logout/index.js
+++ b/app/containers/Logout/index.js
@@ -1,0 +1,22 @@
+/*
+ *
+ * Logout
+ *
+ */
+
+import React from 'react';
+
+import CenteredWrapper from 'components/Wrappers/CenteredWrapper';
+
+
+export default class Logout extends React.PureComponent { // eslint-disable-line react/prefer-stateless-function
+  render() {
+    return (
+      <CenteredWrapper>
+        <div style={{ margin: 14 }}>
+        You are successfully logged out.
+        </div>
+      </CenteredWrapper>
+    );
+  }
+}

--- a/app/containers/Logout/tests/index.test.js
+++ b/app/containers/Logout/tests/index.test.js
@@ -1,0 +1,13 @@
+import Logout from '../index';
+
+import expect from 'expect';
+import { mount } from 'enzyme';
+import React from 'react';
+
+describe('<Logout />', () => {
+  it('should render the successful logout message', () => {
+    const wrapper = mount(<Logout />);
+
+    expect(wrapper.text()).toEqual('You are successfully logged out.');
+  });
+});

--- a/app/containers/ResetPassword/sagas.js
+++ b/app/containers/ResetPassword/sagas.js
@@ -27,7 +27,7 @@ export function* resetPasswordFlow() {
 
     if (wasSuccessful) {
       yield put(resetPasswordSuccess(wasSuccessful));
-      browserHistory.push('/login');
+      yield call(browserHistory.push, '/login');
     }
   }
 }

--- a/app/containers/ResetPassword/tests/sagas.test.js
+++ b/app/containers/ResetPassword/tests/sagas.test.js
@@ -9,6 +9,7 @@ import { call,
          fork,
          cancel } from 'redux-saga/effects';
 import { LOCATION_CHANGE } from 'react-router-redux';
+import { browserHistory } from 'react-router';
 
 import { RESET_PASSWORD } from '../constants';
 import { resetPasswordSuccess } from '../actions';
@@ -40,7 +41,12 @@ describe('resetPasswordFlow Saga', () => {
   it('should dispatch the resetPasswordSuccess action if authorization succeeds', () => {
     const wasSuccessful = true;
     const putDescriptor = resetPasswordFlowGenerator.next(wasSuccessful).value;
-    expect(putDescriptor).toEqual(put(resetPasswordSuccess(true)));
+    expect(putDescriptor).toEqual(put(resetPasswordSuccess(wasSuccessful)));
+  });
+
+  it('should reroute to /login when authorization succeeds', () => {
+    const callDescriptor = resetPasswordFlowGenerator.next().value;
+    expect(callDescriptor).toEqual(call(browserHistory.push, '/login'));
   });
 });
 

--- a/app/reducers.js
+++ b/app/reducers.js
@@ -8,7 +8,6 @@ import { fromJS } from 'immutable';
 import { LOCATION_CHANGE } from 'react-router-redux';
 import languageProviderReducer from 'containers/LanguageProvider/reducer';
 import { reducer as formReducer } from 'redux-form/immutable';
-
 /*
  * routeReducer
  *

--- a/app/routes.js
+++ b/app/routes.js
@@ -16,7 +16,7 @@ export default function createRoutes(store) {
   // Create reusable async injectors using getAsyncInjectors factory
   const { injectReducer, injectSagas } = getAsyncInjectors(store); // eslint-disable-line no-unused-vars
 
-  return [
+  const childRoutes = [
     {
       path: '/',
       name: 'home',
@@ -81,6 +81,14 @@ export default function createRoutes(store) {
         importModules.catch(errorLoading);
       },
     }, {
+      path: '/logout',
+      name: 'logout',
+      getComponent(location, cb) {
+        System.import('containers/Logout')
+          .then(loadModule(cb))
+          .catch(errorLoading);
+      },
+    }, {
       path: '*',
       name: 'notfound',
       getComponent(nextState, cb) {
@@ -90,4 +98,25 @@ export default function createRoutes(store) {
       },
     },
   ];
+
+  return {
+    getComponent(nextState, cb) {
+      const importModules = Promise.all([
+        System.import('containers/App/reducer'),
+        System.import('containers/App/sagas'),
+        System.import('containers/App'),
+      ]);
+
+      const renderRoute = loadModule(cb);
+
+      importModules.then(([reducer, sagas, component]) => {
+        injectReducer('app', reducer.default);
+        injectSagas(sagas.default);
+        renderRoute(component);
+      });
+
+      importModules.catch(errorLoading);
+    },
+    childRoutes,
+  };
 }


### PR DESCRIPTION
- adds global app reducer and saga for logout (next incorporate with login and resetpassword)
    - changes `routes.js` to have all components become a child route of app using solution from https://github.com/react-boilerplate/react-boilerplate/pull/1545
- adds app actions, constants, reducer, saga for logout (next incorporate with login and resetpassword)
- adds app bar 
- redirects to /login if not logged in 